### PR TITLE
Add project info to client_secret.skel

### DIFF
--- a/secrets/client_secrets.skel
+++ b/secrets/client_secrets.skel
@@ -7,6 +7,13 @@
 #    arbitrary, except that you should not use 'admin' or 'test', which
 #    are special built-in databases. 
 #
+# As a convenience, we will use this same credentials file to drive the
+# process of installing and testing your project.  For this we will need
+# your repository URL and your name.
+#
+author = "Your name here"                               # As it appears in Canvas
+repo = "https://github.com/UO-CIS-322/proj6-mongo.git"  # Replace with yours
+server_main = "flask_main"                              # flask_main.py is my main file
 
 # The database we will use within the MongoDB instance
 #
@@ -18,4 +25,3 @@ db = "turnips"
 # 
 db_user = "farmer"
 db_user_pw = "eieio"
-


### PR DESCRIPTION
As per the piazza post, client_secrets.py has three new fields: author,
repo, and server_main. I updated the skeleton code with what was posted
on piazza earlier today.